### PR TITLE
Added docs for Operation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,7 +16,7 @@
 remote_theme: just-the-docs/just-the-docs
 title: MPC Studio Mk2
 description: A Jekyll theme for documentation
-baseurl: "/" # the subpath of your site, e.g. /blog
+baseurl: "MPC-Studio-Mk2-Ableton-Midi-Remote-Script"
 url: "https://bcrowe306.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 permalink: pretty

--- a/docs/operation/application.md
+++ b/docs/operation/application.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Application
-parent: Operation
-nav_order: 3
----

--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -37,13 +37,13 @@ Here's a full list of buttons and their effects, grouped by action type (and if 
 - **Undo**: Undo
 - **Shift**: Accesses extra functionality of Pad Modes, see [Pad modes](../pads/ )
 - **-**/**+**/**Sample Start**/**Sample End**: Move the session view window around, see [Pad mode A](../pads/)
+- **Sample Select**: Toggle moving session window by one clip or by window size
 - **Browse**: Toggles the media browser
 - **Track select**: Jog Wheel track selection mode (currently the only one)
 
 ## Currently unused
 - **Locate**
 - **Program Select**
-- **Sample Select**
 
 ## Mode Button Shortcuts
 Holding down the **Mode** button allows using one of the 8 shortcuts using the pads.

--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: Buttons and Jog Wheel
+parent: Operation
+nav_order: 2
+---
+
+# Intro
+
+A lot of the buttons do exactly what they say they do, with a few exceptions where that functionality does not exist in Ableton Live or there is no API for that.
+Most of the buttons that toggle things will also synchronize their state with the software.
+
+The **Jog Wheel** can be used to select tracks and pressing it down will toggle the selected track's record arm.
+
+Here's a full list of buttons and their effects, grouped by action type (and if possible ordered the way they appear on the device).
+
+## Transport Control
+- **Record**: Toggle Record when in Arrangement View, Session Overdub when in Session View
+- **Overdub**: Toggle Arrangement Overdub
+- **Play**: Play
+- **Stop**: Stop
+- **Play Start**: Toggle Arrangement Loop
+- **<**/**>**: Punch in/Punch out. These are momentary!
+- **<<**/**>>**: Move the playhead
+- **Automation R/W**: Toggles automation read/write - currently slightly bugged, see [GitHub Issue](https://github.com/bcrowe306/MPC-Studio-Mk2-Ableton-Midi-Remote-Script/issues/1)
+
+## Tempo Control
+- **Tap Tempo**: Tap tempo, with visual feedback of the tempo
+- **TC On/Off**: Toggle Record Quantization
+- **Quantize**: Quantizes *all* notes in the currently selected Session View clip.
+- **Tune**: Toggles Metronome
+
+## Software Control
+- **Main**: Toggle Session View / Arrangement View
+- **Mode**: Accesses Shortcuts, see below
+- **Zoom**: Session overview on pads for quick navigation, see [Pad mode A](../pads/)
+- **Undo**: Undo
+- **Shift**: Accesses extra functionality of Pad Modes, see [Pad modes](../pads/ )
+- **-**/**+**/**Sample Start**/**Sample End**: Move the session view window around, see [Pad mode A](../pads/)
+- **Browse**: Toggles the media browser
+- **Track select**: Jog Wheel track selection mode (currently the only one)
+
+## Currently unused
+- **Locate**
+- **Program Select**
+- **Sample Select**
+
+## Mode Button Shortcuts
+Holding down the **Mode** button allows using one of the 8 shortcuts using the pads.
+
+The bottom row of pads is adds tracks, from left to right
+- Audio Track
+- MIDI Track
+- Drum Rack Track
+- Simpler Track
+
+The second to bottom row of pads adds a device to the current track, from left to right 
+- Compressor
+- EQ Three
+- Auto Filter
+- Gate

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -1,0 +1,84 @@
+---
+layout: default
+title: Cheat Sheet
+parent: Operation
+nav_order: 4
+---
+
+# Pad Modes
+
+### A - Session View
+- Launch clips, record clips.
+- Navigate with **-**/**+** and **Sample Start**/**Sample End** or **Zoom**+pad.
+- **Shift** Launch scene
+- Clip Operations:
+  - **Full Level**: Create clip
+  - **Copy**: Copy clip down DESTRUCTIVE
+  - **Pad Mute**: Duplicate clip length
+  - **16 Level**: Select clip
+  - **Erase**: Delete clip
+
+### B - Notes
+- Black keys are blue, white keys are yellow
+- **Shift** Session overview
+- **Full Level** / **Pad Copy**: Change piano octaves / drumkit banks
+- Pad Operations (drumkit only):
+  - **Pad Mute**: Mute pad
+  - **16 Level**: Solo pad
+  - **Erase**: Delete pad
+
+### C - Channel Mixer
+- Track controls:
+  - Select
+  - Mute
+  - Solo
+  - Arm
+- **Shift**: Session overview
+
+### D - Clip stop
+- Momentary
+- Bottom row to stop clips
+
+# Buttons (identical skipped)
+
+### Jog Wheel
+- Turn to select tracks
+- Press to toggle record arm
+
+### Transport
+- **Record**: Record in Arrangement View / Session Overdub in Session View
+- **Overdub**: Arrangement Overdub
+- **Play Start**: Arrangement Loop
+- **<**/**>**: Momentary Punch in / Punch out
+- **<<**/**>>**: Playhead
+- **Automation R/W**: Automation R/W
+
+### Tempo Control
+- **TC On/Off**: Record Quantization
+- **Quantize**: All notes in selected clip
+- **Tune**: Metronome
+
+### Software Control
+- **Main**: Session View / Arrangement View
+- **Zoom**: Session quick navigation
+- **-**/**+**/**Sample Start**/**Sample End**: Session view left/right up/down
+
+### Mode Shortcuts
+- Pads 1-4 - Add Tracks
+  - Audio
+  - MIDI
+  - Drum Rack
+  - Simpler
+- Pads 5-9 - Add FX
+  - Compressor
+  - EQ Three
+  - Auto Filter
+  - Gate
+
+# Touch Strip
+- **Touch Strip** hold to select track parameter:
+  - **Volume**
+  - **Pan**
+  - **Send A**
+  - **Send B**
+- **Note Repeat** + pad + Touch Strip to select interval

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -34,6 +34,12 @@ nav_order: 4
   - Solo
   - Arm
 - **Shift**: Session overview
+- Routing Options:
+  - **Full Level**: MIDI/Audio From
+  - **Copy**: Channel/Track From
+  - **Pad Mute**: MIDI/Audio To Track
+  - **16 Level**: MIDI/Audio To Device
+  - **Erase**: Monitoring
 
 ### D - Clip stop
 - Momentary

--- a/docs/operation/index.md
+++ b/docs/operation/index.md
@@ -4,3 +4,16 @@ title: Operation
 nav_order: 3
 has_children: true
 ---
+# General overview
+{{ page.path }}
+There are 3 main sections of the MPC Studio Mk2 in the context of Ableton Live:
+* Pads and the buttons on the left
+  * These control multiple things about the session and allow note input. More info in the [Pads section](pads/)
+* The buttons to the right, including the jog wheel
+  * These mostly do what they say, with a few exceptions. More info in the [Buttons section](buttons/)
+* The Touch Strip and buttons **Touch Strip** and **Note Repeat**.
+  * These allow controlling some track parameters, provide visual feedback and allow repeated, tempo synchronized note entry. More info in the [Touch Strip section](touchstrip/)
+
+The last section in this page is a single page, easily referencable [Cheat Sheet](cheatsheet/).
+
+Printable PDFs and Diagrams will come soon.

--- a/docs/operation/navigation.md
+++ b/docs/operation/navigation.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Navigation
-parent: Operation
-nav_order: 4
----

--- a/docs/operation/pad_modes.md
+++ b/docs/operation/pad_modes.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Pad Modes
-parent: Operation
-nav_order: 5
----

--- a/docs/operation/pads.md
+++ b/docs/operation/pads.md
@@ -19,7 +19,7 @@ If there is no clip in the corresponding slot, the pad light is off. Otherwise, 
 Playing or queued up clips blink with a green colour. Clips about to start recording blink yellow and then pulse red while recording.
 
 You can navigate around your session in two ways:
-1. Using the **+**/**-** and **Sample Start**/**Sample End** buttons (next to the Jog Wheel) will move the selection window by one clip in each direction.
+1. Using the **+**/**-** and **Sample Start**/**Sample End** buttons (next to the Jog Wheel) will move the selection window around. You can move the window by one clip or by its dimension - this behaviour is toggled with the **Sample Select** button.
 2. Holding the **Zoom** button shows an overview of your entire session and you can use the pads to select a 4x4 block to view.
 
 Holding **SHIFT** allows you to launch scenes by using the rightmost column of pads.

--- a/docs/operation/pads.md
+++ b/docs/operation/pads.md
@@ -1,0 +1,68 @@
+---
+layout: default
+title: Pads and Pad modes
+parent: Operation
+nav_order: 1
+---
+
+# Intro
+
+There are 4 different pad modes, accessed by the Pad Bank buttons A-D.
+Here's a summary of all the modes and a full description follows below.
+
+# Pad Modes Summary
+
+## A - Session View
+
+In this mode, the MPC Studio Mk2 functions similar to a Launchpad, where each pad represents a clip in the Session view of Ableton Live.
+If there is no clip in the corresponding slot, the pad light is off. Otherwise, it matches the colour of the clip.
+Playing or queued up clips blink with a green colour. Clips about to start recording blink yellow and then pulse red while recording.
+
+You can navigate around your session in two ways:
+1. Using the **+**/**-** and **Sample Start**/**Sample End** buttons (next to the Jog Wheel) will move the selection window by one clip in each direction.
+2. Holding the **Zoom** button shows an overview of your entire session and you can use the pads to select a 4x4 block to view.
+
+Holding **SHIFT** allows you to launch scenes by using the rightmost column of pads.
+
+The bottom left buttons can be used to perform operations on clips. You need to hold a button and then select a target clip using pads.
+- **Full Level**: Create a new empty clip with a default length of 2 bars.
+- **Copy**: Create a copy of a clip, paste it directly below. This will overwrite any existing clips!
+- **Pad Mute**: Duplicate a clip length. This will also duplicate the notes in the clip.
+- **16 Level**: Select a clip without playing it.
+- **Erase**: Delete a clip.
+
+## B - Notes
+
+In this mode you can enter trigger notes in the currently armed MIDI tracks. The mode will automatically recognize the type of track and display a drumkit or a piano layout.
+In drumkit mode, only the pads that have samples assigned will be lit up. The currently selected pad is marked and pads will present a visual feedback when pressed.
+In piano mode there are different colours for black and white keys.
+
+Holding **SHIFT** displays a Session Overview (like mode A) so you can quickly launch clips or start/stop recording. 
+
+The **Full Level**/**Copy** buttons can be used to switch drumkit banks or piano octaves up and down. 
+In drumkit mode you can also hold the bottom 3 buttons and select a pad to access extra operations:
+- **Pad mute**: mutes a pad
+- **16 level**: solos a pad
+- **Erase**: deletes a sample from a pad
+
+This mode can also use the **Note Repeat** button to keep entering the selected note, synchronized with the tempo. Hold down the **Note Repeat** button, the pad you want to trigger and use the Touch Strip to select the repeat interval.
+
+## C - Mixer
+
+In this mode each column is a track, and each row is:
+- Select a track
+- Toggle track mute
+- Toggle track solo
+- Toggle track record arm
+
+There is visual feedback for each operation and it is always synchronized with the software. The range of tracks works just like in mode A, and can be moved around the same way (**+**/**-** and **Sample Start**/**Sample End** or **Zoom**).
+
+Holding **SHIFT** displays a Session Overview (like mode A) so you can quickly launch clips or start/stop recording. 
+
+The buttons **Pad mute**, **16 level**, and **Erase** have no effect in this mode.
+
+## D - Clip stop
+
+This mode is momentary, i.e. it is only active as long as you hold the **Pad bank D** button. It allows you to use the bottom row of pads to stop any clips playing in that track.
+
+**Shift** and the lower left buttons are not used in this mode.

--- a/docs/operation/pads.md
+++ b/docs/operation/pads.md
@@ -55,11 +55,14 @@ In this mode each column is a track, and each row is:
 - Toggle track solo
 - Toggle track record arm
 
-There is visual feedback for each operation and it is always synchronized with the software. The range of tracks works just like in mode A, and can be moved around the same way (**+**/**-** and **Sample Start**/**Sample End** or **Zoom**).
+There is visual feedback for each operation, and it is always synchronized with the software. The range of tracks works just like in mode A, and can be moved around the same way (**+**/**-** and **Sample Start**/**Sample End** or **Zoom**).
 
 Holding **SHIFT** displays a Session Overview (like mode A) so you can quickly launch clips or start/stop recording. 
 
-The buttons **Pad mute**, **16 level**, and **Erase** have no effect in this mode.
+The buttons below the pad banks allow controlling the track routing and monitoring options:
+- **Full Level** and **Copy** toggle the values in the Audio/MIDI From combo boxes. You can use them to toggle the input device and channel or track.
+- **Pad Mude** and **16 Level** toggle the values in the Audio/MIDI To combo boxes. You can use them to toggle the output device and channel or track.
+- **Erase** toggles between the available monitoring options (In/Auto/Off)
 
 ## D - Clip stop
 

--- a/docs/operation/touch_strip.md
+++ b/docs/operation/touch_strip.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Touch Strip
-parent: Operation
-nav_order: 6
----

--- a/docs/operation/touchstrip.md
+++ b/docs/operation/touchstrip.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Touch Strip
+parent: Operation
+nav_order: 3
+---
+
+# Intro
+
+There are a few components to the Touch Strip functionality, the Touch Strip itself, the **Touch Strip** button, the red LEDs and the white note division markers (off by default).
+The Touch Strip always affects the currently selected track.
+There are 3 basic ways in which the Touch Strip can be used:
+
+## Track level feedback
+
+When not in use, the red LEDs will display either the track output level (if the track is outputting anything) or the value of the Level parameter (if it's not).
+
+## Track parameter control
+
+Holding the **Touch Strip** button allows a track parameter to be selected using the pads. The top four pads correspond to:
+* Volume
+* Pan
+* Send A
+* Send B
+
+Use the Touch Strip to set the selected parameter for the current track. The Touch Strip will display the current parameter value using the red LEDs while the Touch Strip is held.
+
+## Note Repeat
+
+While in Pad Mode B (Notes), when the **Note Repeat** button and a pad are held down, you can use the Touch Strip to trigger notes repeated in a specific interval, synchronized with the project clock.
+In this mode, the white note division LEDs are lit up and you can hold down a corresponding segment of the Touch Strip to trigger notes at that interval.

--- a/docs/operation/transport.md
+++ b/docs/operation/transport.md
@@ -1,6 +1,0 @@
----
-layout: default
-title: Transport
-parent: Operation
-nav_order: 2
----


### PR DESCRIPTION
This fixes bcrowe306/MPC-Studio-Mk2-Ableton-Midi-Remote-Script#2.

Added a description of all pad modes, buttons, touch strip etc. It's very crude, but a good start.

It would be great to follow this up with some images and a more efficiently organized cheat sheet. I will probably try to work on this in a few days.