### PR TITLE
Zoom+Shift to reset session ring to currently selected track and scene

### DIFF
--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -52,7 +52,7 @@ Turning the Jog Wheel while holding **SHIFT** will move the selected device to t
 ## Software Control
 - **Main**: Toggle Session View / Arrangement View
 - **Mode**: Accesses Shortcuts, see below
-- **Zoom**: Session overview on pads for quick navigation, see [Pad mode A](../pads/)
+- **Zoom**: Session overview on pads for quick navigation, see [Pad mode A](../pads/). **SHIFT** to reset the session ring to currently selected track and scene.
 - **Undo**: Undo
 - **Shift**: Accesses extra functionality of Pad Modes, see [Pad modes](../pads/ )
 - **-**/**+**/**Sample Start**/**Sample End**: Move the session view window around, see [Pad mode A](../pads/)

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -70,7 +70,7 @@ nav_order: 4
 
 ### Software Control
 - **Main**: Session View / Arrangement View
-- **Zoom**: Session quick navigation
+- **Zoom**: Session quick navigation, **SHIFT** jump to current selection
 - **-**/**+**/**Sample Start**/**Sample End**: Session view left/right up/down
 - **Locate**: Toggle bottom panel, **SHIFT** toggle bottom panel content
 

--- a/v11/MPCStudioMk2.py
+++ b/v11/MPCStudioMk2.py
@@ -12,7 +12,7 @@ from .elements.elements import Elements, SESSION_HEIGHT, SESSION_WIDTH
 from .components.keyboard import KeyboardComponent
 from .components.lighting import LightingComponent
 from .components.mixer import MixerComponent
-from .components.session import SessionComponent
+from .components.session import SessionComponent, SessionResetComponent
 from .skin import skin
 from .components.view_toggle import ViewToggleComponent
 from .components.undo import  NewUndoComponent
@@ -29,6 +29,7 @@ from .components.macro import MacroComponent
 from .components.device_navigation import DeviceNavigationComponent
 from .elements.repeat_display_element import RepeatDisplayElement
 from .components.routing_component import RoutingComponent
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ class MPCStudioMk2(ControlSurface):
                 self._create_navigation_modes()
                 self._create_auto_arm()
                 self._create_session()
+                self._create_session_ring_reset()
                 self._create_touch_strip()
                 self._create_touch_strip_modes()
                 self._create_mixer()
@@ -211,7 +213,16 @@ class MPCStudioMk2(ControlSurface):
           session_ring=self._session_ring,
           enable_skinning=True,
           layer=Layer(button_matrix='pads_with_zoom'))
-    
+
+    def _create_session_ring_reset(self):
+        self._session_ring_reset = SessionResetComponent(
+            name='SessionRingReset',
+            session_ring=self._session_ring,
+            is_enabled=False,
+            layer=Layer(reset_session_ring_button='zoom_button_with_shift')
+        )
+        self._session_ring_reset.set_enabled(True)
+
     def _create_touch_strip(self):
         self._touch_strip = TouchStrip(is_enabled=True)
 

--- a/v11/components/session.py
+++ b/v11/components/session.py
@@ -4,6 +4,8 @@ from ableton.v2.base import liveobj_valid, duplicate_clip_loop
 from ableton.v2.control_surface.components import ClipSlotComponent as ClipSlotComponentBase, SceneComponent as SceneComponentBase, SessionComponent as SessionComponentBase
 from ableton.v2.control_surface import ClipCreator
 from ableton.v2.control_surface.control import ButtonControl
+from ableton.v2.control_surface import Component
+
 from ..colors import LIVE_COLOR_INDEX_TO_RGB
 
 def is_button_pressed(button):
@@ -71,5 +73,29 @@ class SessionComponent(SessionComponentBase):
     def set_managed_double_button(self, button):
         self.managed_double_button.set_control_element(button)
         self.set_modifier_button(button, u'double', True)
+
+
+class SessionResetComponent(Component):
+    reset_session_ring_button = ButtonControl()
+
+    def __init__(self, session_ring=None, *a, **k):
+        super(SessionResetComponent, self).__init__(*a, **k)
+        self._session_ring = session_ring
+
+    @reset_session_ring_button.pressed
+    def reset_session_ring(self, button):
+        track_offset = self._session_ring.track_offset
+        scene_offset = self._session_ring.scene_offset
+
+        try:
+            selected_track_index = list(self.song.tracks).index(self.song.view.selected_track)
+        except ValueError:
+            # If this happened then we are probably in a send or master track.
+            # Fallback to the last proper track.
+            selected_track_index = len(list(self.song.tracks)) - 1
+
+        selected_scene_index = list(self.song.scenes).index(self.song.view.selected_scene)
+
+        self._session_ring.move(selected_track_index - track_offset, selected_scene_index - scene_offset)
 
 

--- a/v11/elements/elements.py
+++ b/v11/elements/elements.py
@@ -88,6 +88,8 @@ class Elements(object):
 
         self.undo_button_with_shift = with_modifier(self.shift_button, self.undo_button)
         self.locate_button_with_shift = with_modifier(self.shift_button, self.locate_button)
+        self.zoom_button_with_shift = with_modifier(self.shift_button, self.zoom_button)
+
         self.pads_with_shift = ButtonMatrixElement(name='Pads_With_Shift',rows=(recursive_map(partial(with_modifier, self.shift_button), self.pads_raw)))
         self.pads_with_zoom = ButtonMatrixElement(name='Pads_With_Zoom',rows=(recursive_map(partial(with_modifier, self.zoom_button), self.pads_raw)))
         self.pads_with_pad_mute = ButtonMatrixElement(name='Pads_With_Pad_Mute',rows=(recursive_map(partial(with_modifier, self.pad_mute_button), self.pads_raw)))


### PR DESCRIPTION
One more quick feature - there was a few times when I scrolled away to a track far away from my session ring using the jog wheel. When I wanted to start playing clips from that track, there was an annoying amount of clicking to actually get my session ring to where I already was with my track selector.

This is a very simple solution to that problem, which I think is a nice addition to the session navigation system that we already have in place. Pressing the Zoom button while holding Shift will now make the currently selected clip slot the top left corner of the session ring. 