### PR TITLE
Session Ring Navigation with Shift and Parameter Navigation mode

### DIFF
--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -52,7 +52,7 @@ Turning the Jog Wheel while holding **SHIFT** will move the selected device to t
 ## Software Control
 - **Main**: Toggle Session View / Arrangement View
 - **Mode**: Accesses Shortcuts, see below
-- **Zoom**: Session overview on pads for quick navigation, see [Pad mode A](../pads/)
+- **Zoom**: Session overview on pads for quick navigation, see [Pad mode A](../pads/). **SHIFT** to reset the session ring to currently selected track and scene.
 - **Undo**: Undo
 - **Shift**: Accesses extra functionality of Pad Modes, see [Pad modes](../pads/ )
 - **-**/**+**/**Sample Start**/**Sample End**: Move the session view window around, see [Pad mode A](../pads/)

--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -16,7 +16,7 @@ Holding **SHIFT** while turning the jog wheel will instead select scenes in Sess
 Here's a full list of buttons and their effects, grouped by action type (and if possible ordered the way they appear on the device).
 
 ## Jog Wheel
-There are currently 2 ways that the Jog Wheel can be used - Track Navigation and Device Navigation. They can be selected by using the **Track Select** and **Program Select** buttons respectively.
+There are currently 3 ways that the Jog Wheel can be used - Track Navigation, Device Navigation, and Parameter Navigation. They can be selected by using the **Track Select**, **Program Select**, and **Sample Select** buttons respectively.
 
 ### Track Navigation
 In this mode you can turn the wheel to scroll through tracks. This works both in Session and Arrangement views. If implicit record arm is enabled, it will follow the selection so that the selected track will be armed if possible.
@@ -32,6 +32,12 @@ Pressing the Jog Wheel will turn the device on/off, and pressing it while holdin
 
 Turning the Jog Wheel while holding **SHIFT** will move the selected device to the left or right.
 
+### Parameter Navigation
+In this mode you can use the jog wheel to control a selected parameter. First select the parameter using your mouse (most parameters will respond to being selected with little brackets in the corners), then turn the jog wheel to adjust the parameter value.
+
+For quantized, i.e. discrete parameters each step of the Jog Wheel will switch to the next value.
+
+For continuous parameters, the available range of values is mapped to 100 steps and each step of the Jog Wheel adjusts the value by one step - so if a parameter goes from 0% to 100%, the Jog Wheel will adjust it by 1% at a time. The number of steps can be increased to 1000 by holding the **SHIFT** button, allowing for finer tuning. Pressing the Jog Wheel returns the parameter to its default value, if it has one.
 
 ## Transport Control
 - **Record**: Toggle Record when in Arrangement View, Session Overdub when in Session View

--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -44,9 +44,9 @@ Turning the Jog Wheel while holding **SHIFT** will move the selected device to t
 - **Automation R/W**: Toggles automation read/write - currently slightly bugged, see [GitHub Issue](https://github.com/bcrowe306/MPC-Studio-Mk2-Ableton-Midi-Remote-Script/issues/1)
 
 ## Tempo Control
-- **Tap Tempo**: Tap tempo, with visual feedback of the tempo
+- **Tap Tempo**: Tap tempo, with visual feedback of the tempo. To adjust tempo manually, hold **SHIFT**, **Quantize** and turn the Jog Wheel.
 - **TC On/Off**: Toggle Record Quantization
-- **Quantize**: Quantizes *all* notes in the currently selected Session View clip.
+- **Quantize**: Quantizes *all* notes in the currently selected Session View clip. Hold **SHIFT** and **Quantize**, then use the Jog Wheel to adjust tempo manually.
 - **Tune**: Toggles Metronome
 
 ## Software Control

--- a/docs/operation/buttons.md
+++ b/docs/operation/buttons.md
@@ -55,8 +55,7 @@ Turning the Jog Wheel while holding **SHIFT** will move the selected device to t
 - **Zoom**: Session overview on pads for quick navigation, see [Pad mode A](../pads/). **SHIFT** to reset the session ring to currently selected track and scene.
 - **Undo**: Undo
 - **Shift**: Accesses extra functionality of Pad Modes, see [Pad modes](../pads/ )
-- **-**/**+**/**Sample Start**/**Sample End**: Move the session view window around, see [Pad mode A](../pads/)
-- **Sample Select**: Toggle moving session window by one clip or by window size
+- **-**/**+**/**Sample Start**/**Sample End**: Move the session view window around, **SHIFT** for paged navigation, see [Pad mode A](../pads/)
 - **Browse**: Toggles the media browser
 - **Track select**: Jog Wheel track selection mode (currently the only one) **SHIFT** to select scenes
 

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -54,6 +54,10 @@ nav_order: 4
 - Device Navigation (**Program Select**)
   - Turn to select devices, **SHIFT** to move devices
   - Press to toggle device enabled, **SHIFT** to toggle device collapsed
+- Parameter Navigation (**Sample Select**)
+  - Select a parameter using the mouse first
+  - Turn to adjust by one option or 1%, **SHIFT** for fine-tuning at 0,1%
+  - Press to reset to default value
 - Tempo adjustment holding **SHIFT** and **Quantize**
 
 ### Transport

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -54,6 +54,7 @@ nav_order: 4
 - Device Navigation (**Program Select**)
   - Turn to select devices, **SHIFT** to move devices
   - Press to toggle device enabled, **SHIFT** to toggle device collapsed
+- Tempo adjustment holding **SHIFT** and **Quantize**
 
 ### Transport
 - **Record**: Record in Arrangement View / Session Overdub in Session View

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -71,7 +71,7 @@ nav_order: 4
 
 ### Software Control
 - **Main**: Session View / Arrangement View
-- **Zoom**: Session quick navigation
+- **Zoom**: Session quick navigation, **SHIFT** jump to current selection
 - **-**/**+**/**Sample Start**/**Sample End**: Session view left/right up/down
 - **Locate**: Toggle bottom panel, **SHIFT** toggle bottom panel content
 

--- a/docs/operation/cheatsheet.md
+++ b/docs/operation/cheatsheet.md
@@ -72,7 +72,7 @@ nav_order: 4
 ### Software Control
 - **Main**: Session View / Arrangement View
 - **Zoom**: Session quick navigation, **SHIFT** jump to current selection
-- **-**/**+**/**Sample Start**/**Sample End**: Session view left/right up/down
+- **-**/**+**/**Sample Start**/**Sample End**: Session view left/right up/down, **SHIFT** for paged
 - **Locate**: Toggle bottom panel, **SHIFT** toggle bottom panel content
 
 ### Mode Shortcuts

--- a/v11/MPCStudioMk2.py
+++ b/v11/MPCStudioMk2.py
@@ -12,7 +12,7 @@ from .elements.elements import Elements, SESSION_HEIGHT, SESSION_WIDTH
 from .components.keyboard import KeyboardComponent
 from .components.lighting import LightingComponent
 from .components.mixer import MixerComponent
-from .components.session import SessionComponent
+from .components.session import SessionComponent, SessionResetComponent
 from .skin import skin
 from .components.view_toggle import ViewToggleComponent
 from .components.undo import  NewUndoComponent
@@ -29,6 +29,7 @@ from .components.macro import MacroComponent
 from .components.device_navigation import DeviceNavigationComponent
 from .elements.repeat_display_element import RepeatDisplayElement
 from .components.routing_component import RoutingComponent
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ class MPCStudioMk2(ControlSurface):
                 self._create_navigation_modes()
                 self._create_auto_arm()
                 self._create_session()
+                self._create_session_ring_reset()
                 self._create_touch_strip()
                 self._create_touch_strip_modes()
                 self._create_mixer()
@@ -215,7 +217,16 @@ class MPCStudioMk2(ControlSurface):
           session_ring=self._session_ring,
           enable_skinning=True,
           layer=Layer(button_matrix='pads_with_zoom'))
-    
+
+    def _create_session_ring_reset(self):
+        self._session_ring_reset = SessionResetComponent(
+            name='SessionRingReset',
+            session_ring=self._session_ring,
+            is_enabled=False,
+            layer=Layer(reset_session_ring_button='zoom_button_with_shift')
+        )
+        self._session_ring_reset.set_enabled(True)
+
     def _create_touch_strip(self):
         self._touch_strip = TouchStrip(is_enabled=True)
 

--- a/v11/MPCStudioMk2.py
+++ b/v11/MPCStudioMk2.py
@@ -273,9 +273,14 @@ class MPCStudioMk2(ControlSurface):
             self.application.view.focus_view(u'Detail')
 
     def _create_session_navigation_modes(self):
-        self._session_navigation_modes = ModesComponent(name='Session_Navigation_Modes',
-          is_enabled=False,
-          layer=Layer(cycle_mode_button='sample_select_button'))
+        self._session_navigation_modes = ModesComponent(
+            name='Session_Navigation_Modes',
+            is_enabled=False,
+            support_momentary_mode_cycling=True,
+            layer=Layer(
+                cycle_mode_button='shift_button'
+            )
+        )
 
         self._session_navigation_modes.add_mode('default',
             AddLayerMode((self._session_navigation),

--- a/v11/MPCStudioMk2.py
+++ b/v11/MPCStudioMk2.py
@@ -128,14 +128,18 @@ class MPCStudioMk2(ControlSurface):
         self._lighting.set_enabled(True)
 
     def _create_transport(self):
-        self._transport = TransportComponent(name='Transport',
-          is_enabled=False,
-          layer=Layer(priority=5, 
-          play_button='play_button',
-          loop_button='play_start_button',
-          stop_button='stop_button',
-          metronome_button='tune_button',
-          tap_tempo_button='tap_tempo_button'))
+        self._transport = TransportComponent(
+            name='Transport',
+            is_enabled=False,
+            layer=Layer(
+                priority=5,
+                play_button='play_button',
+                loop_button='play_start_button',
+                stop_button='stop_button',
+                metronome_button='tune_button',
+                tap_tempo_button='tap_tempo_button'
+            )
+        )
         self._transport.set_enabled(True)
         self._transport.set_seek_forward_button(self._elements.seek_forward_button)
         self._transport.set_seek_backward_button(self._elements.seek_back_button)
@@ -239,11 +243,13 @@ class MPCStudioMk2(ControlSurface):
         self._navigation_modes.add_mode('track', AddLayerMode(TrackNavigationComponent(), Layer(
                 jog_wheel_button='jog_wheel',
                 arm_button='jog_wheel_button',
-                shift_button='shift_button')))
+                shift_button='shift_button',
+                tempo_button='quantize_button_with_shift')))
         self._navigation_modes.add_mode('device', AddLayerMode(DeviceNavigationComponent(), Layer(
                 jog_wheel_button='jog_wheel',
                 jog_wheel_press='jog_wheel_button',
-                shift_button='shift_button')))
+                shift_button='shift_button',
+                tempo_button='quantize_button_with_shift')))
         self._navigation_modes.selected_mode = 'track'
         self._navigation_modes.set_enabled(True)
         self._on__navigation_modes_changed.subject = self._navigation_modes

--- a/v11/MPCStudioMk2.py
+++ b/v11/MPCStudioMk2.py
@@ -4,6 +4,7 @@ from ableton.v2.control_surface import ControlSurface, Layer, PercussionInstrume
 from ableton.v2.control_surface.components import ArmedTargetTrackComponent, BackgroundComponent, AccentComponent, SessionNavigationComponent, SessionOverviewComponent, SessionRingComponent, SimpleTrackAssigner, AutoArmComponent
 from ableton.v2.control_surface.mode import AddLayerMode, LayerMode, ModesComponent, MomentaryBehaviour
 from ableton.v2.control_surface.control.button import ButtonControl
+from .components.parameter_navigation import ParameterNavigationComponent
 from .elements.mpc_elements import MPCButtonElement
 from . import midi
 from .components.channel_strip import ChannelStripComponent
@@ -249,7 +250,8 @@ class MPCStudioMk2(ControlSurface):
     def _create_navigation_modes(self):
         self._navigation_modes = ModesComponent(name='Navigation_Modes', is_enabled=False, layer=Layer(
             track_button='track_select_button',
-            device_button='program_select_button'
+            device_button='program_select_button',
+            parameter_button='sample_select_button'
         ))
         self._navigation_modes.add_mode('track', AddLayerMode(TrackNavigationComponent(), Layer(
                 jog_wheel_button='jog_wheel',
@@ -257,6 +259,11 @@ class MPCStudioMk2(ControlSurface):
                 shift_button='shift_button',
                 tempo_button='quantize_button_with_shift')))
         self._navigation_modes.add_mode('device', AddLayerMode(DeviceNavigationComponent(), Layer(
+                jog_wheel_button='jog_wheel',
+                jog_wheel_press='jog_wheel_button',
+                shift_button='shift_button',
+                tempo_button='quantize_button_with_shift')))
+        self._navigation_modes.add_mode('parameter', AddLayerMode(ParameterNavigationComponent(), Layer(
                 jog_wheel_button='jog_wheel',
                 jog_wheel_press='jog_wheel_button',
                 shift_button='shift_button',
@@ -270,6 +277,8 @@ class MPCStudioMk2(ControlSurface):
         if mode == 'track':
             self.application.view.focus_view(u'Session')
         if mode == 'device':
+            self.application.view.focus_view(u'Detail')
+        if mode == 'parameter':
             self.application.view.focus_view(u'Detail')
 
     def _create_session_navigation_modes(self):

--- a/v11/components/device_navigation.py
+++ b/v11/components/device_navigation.py
@@ -11,6 +11,7 @@ class DeviceNavigationComponent(Component):
     jog_wheel_button = ButtonControl()
     jog_wheel_press = ButtonControl()
     shift_button = ButtonControl()
+    tempo_button = ButtonControl()
 
     def __init__(self, *a, **k):
         super(DeviceNavigationComponent, self).__init__(*a, **k)
@@ -47,7 +48,9 @@ class DeviceNavigationComponent(Component):
 
     @jog_wheel_button.value
     def _on_jog_wheel_turn(self, x, _):
-        if self.shift_button.is_pressed:
+        if self.tempo_button.is_pressed:
+            self._adjust_tempo(x)
+        elif self.shift_button.is_pressed:
             device = self.song.view.selected_track.view.selected_device
             if device is None:
                 return
@@ -60,3 +63,7 @@ class DeviceNavigationComponent(Component):
                 self.application.view.scroll_view(NavDirection.right, 'Detail/DeviceChain', False)
             if x == 127:
                 self.application.view.scroll_view(NavDirection.left, 'Detail/DeviceChain', False)
+
+    def _adjust_tempo(self, x):
+        factor = 1 if x == 1 else -1
+        self.song.tempo = max(min(int(self.song.tempo) + factor, 999), 20)

--- a/v11/components/parameter_navigation.py
+++ b/v11/components/parameter_navigation.py
@@ -1,0 +1,77 @@
+import Live
+from ableton.v2.control_surface import Component
+from ableton.v2.control_surface.control.button import ButtonControl
+NavDirection = Live.Application.Application.View.NavDirection
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def clamp(val, minv, maxv):
+    return max(minv, min(val, maxv))
+
+
+def _adjust_parameter(parameter, offset, fine_tune):
+    if parameter.is_quantized:
+        parameter.value = clamp(parameter.value + offset, parameter.min, parameter.max)
+    else:
+        range = abs(parameter.max - parameter.min)
+        step = (range / 100) * fine_tune
+        delta = step * offset
+        parameter.value = clamp(parameter.value + delta, parameter.min, parameter.max)
+
+
+class ParameterNavigationComponent(Component):
+    jog_wheel_button = ButtonControl()
+    jog_wheel_press = ButtonControl()
+    shift_button = ButtonControl()
+    tempo_button = ButtonControl()
+
+    def __init__(self, *a, **k):
+        super(ParameterNavigationComponent, self).__init__(*a, **k)
+
+    @staticmethod
+    def is_device_enabled(device):
+        return bool(device.parameters[0].value)
+
+    @staticmethod
+    def set_device_enabled(device, enabled):
+        device.parameters[0].value = int(enabled)
+
+    def move_device_left(self, device):
+        parent = device.canonical_parent
+        device_index = list(parent.devices).index(device)
+        if device_index > 0:
+            self.song.move_device(device, parent, device_index - 1)
+
+    def move_device_right(self, device):
+        parent = device.canonical_parent
+        device_index = list(parent.devices).index(device)
+        if device_index < len(parent.devices) - 1:
+            self.song.move_device(device, parent, device_index + 2)
+
+    @jog_wheel_press.pressed
+    def _on_jog_wheel_pressed(self, value):
+        parameter = self.song.view.selected_parameter
+        if not parameter.is_quantized:
+            parameter.value = parameter.default_value
+
+
+    @jog_wheel_button.value
+    def _on_jog_wheel_turn(self, x, _):
+        parameter = self.song.view.selected_parameter
+        if self.tempo_button.is_pressed:
+            self._adjust_tempo(x)
+        elif parameter is not None:
+            fine_tune = 1
+            if self.shift_button.is_pressed:
+                fine_tune = 0.1
+            if x == 1:
+                _adjust_parameter(parameter, 1, fine_tune)
+            if x == 127:
+                _adjust_parameter(parameter, -1, fine_tune)
+
+    def _adjust_tempo(self, x):
+        factor = 1 if x == 1 else -1
+        self.song.tempo = max(min(int(self.song.tempo) + factor, 999), 20)
+

--- a/v11/components/session.py
+++ b/v11/components/session.py
@@ -4,6 +4,8 @@ from ableton.v2.base import liveobj_valid, duplicate_clip_loop
 from ableton.v2.control_surface.components import ClipSlotComponent as ClipSlotComponentBase, SceneComponent as SceneComponentBase, SessionComponent as SessionComponentBase
 from ableton.v2.control_surface import ClipCreator
 from ableton.v2.control_surface.control import ButtonControl
+from ableton.v2.control_surface import Component
+
 from ..colors import LIVE_COLOR_INDEX_TO_RGB
 
 def is_button_pressed(button):
@@ -71,5 +73,29 @@ class SessionComponent(SessionComponentBase):
     def set_managed_double_button(self, button):
         self.managed_double_button.set_control_element(button)
         self.set_modifier_button(button, u'double', True)
+
+
+class SessionResetComponent(Component):
+    reset_session_ring_button = ButtonControl()
+
+    def __init__(self, session_ring=None, *a, **k):
+        super(SessionResetComponent, self).__init__(*a, **k)
+        self._session_ring = session_ring
+
+    @reset_session_ring_button.pressed
+    def reset_session_ring(self, button):
+        track_offset = self._session_ring.track_offset
+        scene_offset = self._session_ring.scene_offset
+
+        try:
+            selected_track_index = list(self.song.tracks).index(self.song.view.selected_track)
+        except ValueError:
+            # If this happened then we are probably in a send or master track.
+            # Fallback to the last proper track.
+            selected_track_index = len(list(self.song.tracks)) - 1
+
+        selected_scene_index = list(self.song.scenes).index(self.song.view.selected_scene)
+
+        self._session_ring.move(selected_track_index - track_offset, selected_scene_index - scene_offset)
 
 

--- a/v11/components/track_navigation.py
+++ b/v11/components/track_navigation.py
@@ -12,6 +12,7 @@ class TrackNavigationComponent(Component):
     jog_wheel_button = ButtonControl()
     arm_button = ButtonControl()
     shift_button = ButtonControl()
+    tempo_button = ButtonControl()
 
     def __init__(self, *a, **k):
         super(TrackNavigationComponent, self).__init__(*a, **k)
@@ -44,7 +45,6 @@ class TrackNavigationComponent(Component):
         self._arm_button = None
         super(TrackNavigationComponent, self).disconnect()
 
-
     def _arm_value(self, value):
         if self.is_enabled():
             if liveobj_valid(self._track) and self._track.can_be_armed:
@@ -63,7 +63,9 @@ class TrackNavigationComponent(Component):
     
     @jog_wheel_button.value
     def undo_button(self, x, _):
-        if self.shift_button.is_pressed:
+        if self.tempo_button.is_pressed:
+            self._adjust_tempo(x)
+        elif self.shift_button.is_pressed:
             if x == 1 and self._can_select_next_scene():
                 self._select_next_scene()
             if x == 127 and self._can_select_prev_scene():
@@ -123,3 +125,7 @@ class TrackNavigationComponent(Component):
     def _select_next_scene(self):
         index = self.selected_scene_index() + 1
         self.song.view.selected_scene = self.song.scenes[index]
+
+    def _adjust_tempo(self, x):
+        factor = 1 if x == 1 else -1
+        self.song.tempo = max(min(int(self.song.tempo) + factor, 999), 20)

--- a/v11/elements/elements.py
+++ b/v11/elements/elements.py
@@ -86,8 +86,10 @@ class Elements(object):
             self.pads_raw.append(row)
         self.pads = ButtonMatrixElement(rows=(self.pads_raw), name='Pads')
 
+        self.quantize_button_with_shift = with_modifier(self.shift_button, self.quantize_button)
         self.undo_button_with_shift = with_modifier(self.shift_button, self.undo_button)
         self.locate_button_with_shift = with_modifier(self.shift_button, self.locate_button)
+
         self.pads_with_shift = ButtonMatrixElement(name='Pads_With_Shift',rows=(recursive_map(partial(with_modifier, self.shift_button), self.pads_raw)))
         self.pads_with_zoom = ButtonMatrixElement(name='Pads_With_Zoom',rows=(recursive_map(partial(with_modifier, self.zoom_button), self.pads_raw)))
         self.pads_with_pad_mute = ButtonMatrixElement(name='Pads_With_Pad_Mute',rows=(recursive_map(partial(with_modifier, self.pad_mute_button), self.pads_raw)))

--- a/v11/elements/elements.py
+++ b/v11/elements/elements.py
@@ -89,6 +89,7 @@ class Elements(object):
         self.quantize_button_with_shift = with_modifier(self.shift_button, self.quantize_button)
         self.undo_button_with_shift = with_modifier(self.shift_button, self.undo_button)
         self.locate_button_with_shift = with_modifier(self.shift_button, self.locate_button)
+        self.zoom_button_with_shift = with_modifier(self.shift_button, self.zoom_button)
 
         self.pads_with_shift = ButtonMatrixElement(name='Pads_With_Shift',rows=(recursive_map(partial(with_modifier, self.shift_button), self.pads_raw)))
         self.pads_with_zoom = ButtonMatrixElement(name='Pads_With_Zoom',rows=(recursive_map(partial(with_modifier, self.zoom_button), self.pads_raw)))


### PR DESCRIPTION
Two changes here (only look at the last two commits, the rest is other PRs that this is based upon):

1. Switching the session ring navigation between default and paged is now done momentarily with the Shift button - i.e. pressing Sample End moves it down by one clip, pressing Shift + Sample End moves it down by one page. I was thinking that we don't use the Shift button enough and there's many more features that we can cram into this device. Doing the session ring navigation this way gives us back the Sample Select button, and is arguably intuitive because you don't have to think about which mode you're in, you always know what the buttons will do.
2. Sample Select is now free for a third Jog Wheel mode - and since we can already move around tracks and scenes and devices, the next logical step is device parameters. Now I honestly tried everything I could to have the Jog Wheel select parameters as well as just adjust them. My ideal UX for this would be turn the jog wheel to select a parameter, shift to adjust it, possibly shift+something else to fine tune. However, there is no way to set the currently selected parameter - not one that I could find anyway. I even tried to make Ableton select the parameter for me by jiggling it around but to no effect. Still, I think this might be a useful feature.